### PR TITLE
リプライ画面を実装した

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "next/babel",
+      {
+        "preset-react": {
+          "runtime": "automatic",
+          "importSource": "@emotion/react"
+        }
+      }
+    ]
+  ],
+  "plugins": ["@emotion/babel-plugin"]
+}

--- a/client/components/CreatingPost.tsx
+++ b/client/components/CreatingPost.tsx
@@ -1,4 +1,5 @@
 import { getCookie } from 'cookies-next';
+import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
@@ -12,20 +13,22 @@ import TextareaAutosize from '@mui/base/TextareaAutosize';
 
 const style = {
   position: 'absolute' as 'absolute',
-  top: '25%',
+  top: '20%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 800,
-  bgcolor: 'background.paper',
-  border: '2px solid #000',
+  bgcolor: 'background.default',
+  border: 'none',
   boxShadow: 24,
   p: 4,
+  borderRadius: '5%',
 };
 
 const CreatingPost = () => {
+  const theme = useTheme();
   return (
     <Box sx={style}>
-      <Card sx={{ width: 900 }}>
+      <Card>
         <CardHeader
           avatar={<Avatar src={getCookie('photoURL') as string} aria-label='icon' />}
           title={getCookie('userName') + '@' + getCookie('userId')}
@@ -35,7 +38,17 @@ const CreatingPost = () => {
             aria-label='posttext'
             placeholder='投稿を書き込んでください'
             minRows={3}
-            style={{ width: '100%' }}
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+              border: 'none',
+              resize: 'none',
+              outline: 'none',
+              backgroundColor: 'inherit',
+              color: theme.palette.text.primary,
+              fontSize: 18,
+              borderRadius: '5%',
+            }}
           />
         </CardContent>
         <CardActions disableSpacing>

--- a/client/components/CreatingPost.tsx
+++ b/client/components/CreatingPost.tsx
@@ -1,67 +1,93 @@
+import React from 'react';
 import { getCookie } from 'cookies-next';
 import { useTheme } from '@mui/material/styles';
-import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
 import CardActions from '@mui/material/CardActions';
+import Fab from '@mui/material/Fab';
 import AddPhotoAlternateOutlinedIcon from '@mui/icons-material/AddPhotoAlternateOutlined';
 import PollOutlinedIcon from '@mui/icons-material/PollOutlined';
 import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
+import PublishIcon from '@mui/icons-material/Publish';
 import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { CardProps } from '@mui/material';
 
 const style = {
   position: 'absolute' as 'absolute',
+  padding: '0px',
   top: '20%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: 800,
+  width: 680,
   bgcolor: 'background.default',
   border: 'none',
   boxShadow: 24,
   p: 4,
-  borderRadius: '5%',
+  borderRadius: 5,
+  '& .MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded.MuiPaper-elevation1.MuiCard-root.MuiPaper-root-MuiCard-root':
+    {
+      padding: 0,
+    },
 };
 
-const CreatingPost = () => {
+type CreatingPostProps = CardProps & { handleClose: () => void };
+
+const CreatingPost = React.forwardRef<HTMLDivElement, CreatingPostProps>(function CreatingPostImpl(
+  { handleClose, ...cardProps }: CreatingPostProps,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
+  const sendPost = () => {
+    // DB に投稿を送信する
+    handleClose();
+  };
+
   const theme = useTheme();
+
   return (
-    <Box sx={style}>
-      <Card>
-        <CardHeader
-          avatar={<Avatar src={getCookie('photoURL') as string} aria-label='icon' />}
-          title={getCookie('userName') + '@' + getCookie('userId')}
+    <Card sx={style} ref={ref} {...cardProps}>
+      <CardHeader
+        avatar={<Avatar src={getCookie('photoURL') as string} aria-label='icon' />}
+        title={getCookie('userName') + '@' + getCookie('userId')}
+      />
+      <CardContent>
+        <TextareaAutosize
+          aria-label='posttext'
+          placeholder='投稿を書き込んでください'
+          minRows={3}
+          style={{
+            width: '100%',
+            boxSizing: 'border-box',
+            border: 'none',
+            resize: 'none',
+            outline: 'none',
+            backgroundColor: 'inherit',
+            color: theme.palette.text.primary,
+            fontSize: 18,
+          }}
         />
-        <CardContent>
-          <TextareaAutosize
-            aria-label='posttext'
-            placeholder='投稿を書き込んでください'
-            minRows={3}
-            style={{
-              width: '100%',
-              boxSizing: 'border-box',
-              border: 'none',
-              resize: 'none',
-              outline: 'none',
-              backgroundColor: 'inherit',
-              color: theme.palette.text.primary,
-              fontSize: 18,
-              borderRadius: '5%',
-            }}
-          />
-        </CardContent>
-        <CardActions disableSpacing>
-          <IconButton aria-label='add image'>
-            <AddPhotoAlternateOutlinedIcon />
-          </IconButton>
-          <IconButton aria-label='add poll'>
-            <PollOutlinedIcon />
-          </IconButton>
-        </CardActions>
-      </Card>
-    </Box>
+      </CardContent>
+      <CardActions disableSpacing>
+        <IconButton aria-label='add image'>
+          <AddPhotoAlternateOutlinedIcon />
+        </IconButton>
+        <IconButton aria-label='add poll'>
+          <PollOutlinedIcon />
+        </IconButton>
+        <Fab
+          variant='extended'
+          color='primary'
+          onClick={sendPost}
+          aria-label='send post'
+          sx={{ width: 'auto', marginRight: 0, marginLeft: 'auto' }}
+        >
+          <PublishIcon />
+          投稿
+        </Fab>
+      </CardActions>
+    </Card>
   );
-};
+});
 
 export default CreatingPost;

--- a/client/components/LeftMenuBar.tsx
+++ b/client/components/LeftMenuBar.tsx
@@ -11,6 +11,7 @@ import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import BookmarkBorderOutlinedIcon from '@mui/icons-material/BookmarkBorderOutlined';
 import CreateIcon from '@mui/icons-material/Create';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -19,7 +20,7 @@ import Modal from '@mui/material/Modal';
 import CreatingPost from './CreatingPost';
 
 export const LeftMenuBarWidthWhenGreaterThanMd = 240;
-export const LeftMenuBarWidthWhenLessThanMd = 50;
+export const LeftMenuBarWidthWhenLessThanMd = 70;
 
 const LeftMenuBar = () => {
   // DB から通知数を取得
@@ -67,10 +68,30 @@ const LeftMenuBar = () => {
               {matches && <ListItemText primary='Bookmarks' />}
             </ListItemButton>
           </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <SettingsOutlinedIcon />
+              </ListItemIcon>
+              {matches && <ListItemText primary='Settings' />}
+            </ListItemButton>
+          </ListItem>
         </List>
-        <Fab variant='extended' color='primary' onClick={handleOpen} area-label='create post'>
+        <Fab
+          variant='extended'
+          color='primary'
+          onClick={handleOpen}
+          area-label='create post'
+          sx={{
+            width: matches
+              ? 0.7 * LeftMenuBarWidthWhenGreaterThanMd
+              : LeftMenuBarWidthWhenLessThanMd,
+            marginLeft: 'auto',
+            marginRight: 'auto',
+          }}
+        >
           <CreateIcon />
-          {matches && 'Post'}
+          {matches && '投稿'}
         </Fab>
         <Modal
           open={isOpen}
@@ -78,7 +99,7 @@ const LeftMenuBar = () => {
           aria-labelledby='modal-modal-title'
           aria-describedby='modal-modal-description'
         >
-          <CreatingPost />
+          <CreatingPost handleClose={handleClose} />
         </Modal>
       </Stack>
     </Box>

--- a/client/components/LeftMenuBar.tsx
+++ b/client/components/LeftMenuBar.tsx
@@ -18,6 +18,9 @@ import Fab from '@mui/material/Fab';
 import Modal from '@mui/material/Modal';
 import CreatingPost from './CreatingPost';
 
+export const LeftMenuBarWidthWhenGreaterThanMd = 240;
+export const LeftMenuBarWidthWhenLessThanMd = 50;
+
 const LeftMenuBar = () => {
   // DB から通知数を取得
   let notificationCount = 1;
@@ -30,50 +33,55 @@ const LeftMenuBar = () => {
   const matches = useMediaQuery(theme.breakpoints.up('md'));
 
   return (
-    <Stack divider={<Divider flexItem />}>
-      <List>
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <HomeOutlinedIcon />
-            </ListItemIcon>
-            {matches && <ListItemText primary='Home' />}
-          </ListItemButton>
-        </ListItem>
-        <Divider />
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <Badge badgeContent={notificationCount} color='secondary'>
-                <NotificationsNoneOutlinedIcon />
-              </Badge>
-            </ListItemIcon>
-            {matches && <ListItemText primary='Notification' />}
-          </ListItemButton>
-        </ListItem>
-        <Divider />
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <BookmarkBorderOutlinedIcon />
-            </ListItemIcon>
-            {matches && <ListItemText primary='Bookmarks' />}
-          </ListItemButton>
-        </ListItem>
-      </List>
-      <Fab variant='extended' color='primary' onClick={handleOpen} area-label='create post'>
-        <CreateIcon />
-        {matches && 'Post'}
-      </Fab>
-      <Modal
-        open={isOpen}
-        onClose={handleClose}
-        aria-labelledby='modal-modal-title'
-        aria-describedby='modal-modal-description'
-      >
-        <CreatingPost />
-      </Modal>
-    </Stack>
+    <Box
+      sx={{
+        width: matches ? LeftMenuBarWidthWhenGreaterThanMd : LeftMenuBarWidthWhenLessThanMd,
+        flexShrink: { md: 0 },
+      }}
+    >
+      <Stack divider={<Divider flexItem />}>
+        <List>
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <HomeOutlinedIcon />
+              </ListItemIcon>
+              {matches && <ListItemText primary='Home' />}
+            </ListItemButton>
+          </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <Badge badgeContent={notificationCount} color='secondary'>
+                  <NotificationsNoneOutlinedIcon />
+                </Badge>
+              </ListItemIcon>
+              {matches && <ListItemText primary='Notification' />}
+            </ListItemButton>
+          </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <BookmarkBorderOutlinedIcon />
+              </ListItemIcon>
+              {matches && <ListItemText primary='Bookmarks' />}
+            </ListItemButton>
+          </ListItem>
+        </List>
+        <Fab variant='extended' color='primary' onClick={handleOpen} area-label='create post'>
+          <CreateIcon />
+          {matches && 'Post'}
+        </Fab>
+        <Modal
+          open={isOpen}
+          onClose={handleClose}
+          aria-labelledby='modal-modal-title'
+          aria-describedby='modal-modal-description'
+        >
+          <CreatingPost />
+        </Modal>
+      </Stack>
+    </Box>
   );
 };
 

--- a/client/components/Post.tsx
+++ b/client/components/Post.tsx
@@ -1,20 +1,14 @@
-import { styled } from '@mui/material/styles';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
-import CardMedia from '@mui/material/CardMedia';
 import CardContent from '@mui/material/CardContent';
 import CardActions from '@mui/material/CardActions';
-import Collapse from '@mui/material/Collapse';
 import Avatar from '@mui/material/Avatar';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
-import { red } from '@mui/material/colors';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import ShareIcon from '@mui/icons-material/Share';
 import ReplyIcon from '@mui/icons-material/Reply';
 import RepeatIcon from '@mui/icons-material/Repeat';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Details from './Details';
 
 export interface PostProps {
@@ -47,7 +41,7 @@ const Post = (props: PostProps) => {
   let postHTML: JSX.Element = <span>Welcome to UEC!</span>;
 
   return (
-    <Card sx={{ width: 550 }}>
+    <Card sx={{ width: 600 }}>
       <CardHeader
         avatar={<Avatar src={props.photoURL} aria-label='icon' />}
         action={<Details postId={props.postId} />}

--- a/client/components/Post.tsx
+++ b/client/components/Post.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+import { useTheme } from '@mui/material/styles';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
@@ -9,9 +11,12 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import ShareIcon from '@mui/icons-material/Share';
 import ReplyIcon from '@mui/icons-material/Reply';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import Modal from '@mui/material/Modal';
 import Details from './Details';
+import ReplyingToPost from './ReplyingToPost';
+import { CardProps } from '@mui/material';
 
-export interface PostProps {
+export type PostProps = CardProps & {
   postId: number;
   photoURL: string;
   userName: string;
@@ -23,9 +28,25 @@ export interface PostProps {
   postTime: string;
   isFavedByU: boolean;
   isRepostedByU: boolean;
-}
+};
 
-const Post = (props: PostProps) => {
+const Post = React.forwardRef<HTMLDivElement, PostProps>(function PostImpl(
+  {
+    postId,
+    photoURL,
+    userName,
+    userId,
+    postText,
+    replyCount,
+    repostCount,
+    favCount,
+    postTime,
+    isFavedByU,
+    isRepostedByU,
+    ...cardProps
+  }: PostProps,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
   // render() の実装は以下の通りにする
 
   // services/get-post.ts を使って，postId から photoURL，username，postText などを読みだす．
@@ -40,34 +61,63 @@ const Post = (props: PostProps) => {
   // let postHTML: JSX.Element = useMemo(() => render(postText), [postText])
   let postHTML: JSX.Element = <span>Welcome to UEC!</span>;
 
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const theme = useTheme();
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
   return (
-    <Card sx={{ width: 600 }}>
+    <Card sx={{ width: 600 }} ref={ref} {...cardProps}>
       <CardHeader
-        avatar={<Avatar src={props.photoURL} aria-label='icon' />}
-        action={<Details postId={props.postId} />}
-        title={props.userName + '@' + props.userId}
-        subheader={props.postTime}
+        avatar={<Avatar src={photoURL} aria-label='icon' />}
+        action={<Details postId={postId} />}
+        title={userName + '@' + userId}
+        subheader={postTime}
       />
       <CardContent>{postHTML}</CardContent>
       <CardActions disableSpacing>
-        <IconButton aria-label='reply'>
-          <ReplyIcon />
-        </IconButton>
-        <Typography variant='body2'>{props.replyCount}</Typography>
+        <ReplyIcon onClick={handleOpen} />
+        <Modal
+          open={isOpen}
+          onClose={handleClose}
+          aria-labelledby='modal-modal-title'
+          aria-describedby='modal-modal-description'
+          sx={{ '& .MuiPaper-root-MuiCard-root': { padding: 0 } }}
+        >
+          <ReplyingToPost
+            postId={postId}
+            photoURL={photoURL}
+            userName={userName}
+            userId={userId}
+            postText={postText}
+            replyCount={replyCount}
+            repostCount={repostCount}
+            favCount={favCount}
+            postTime={postTime}
+            isFavedByU={isFavedByU}
+            isRepostedByU={isRepostedByU}
+            postHTML={postHTML}
+            handleClose={handleClose}
+          />
+        </Modal>
+        <Typography variant='body2'>{replyCount}</Typography>
         <IconButton aria-label='repost'>
+          {/* Repost の処理の呼び出しを行う */}
           <RepeatIcon />
         </IconButton>
-        <Typography variant='body2'>{props.repostCount}</Typography>
+        <Typography variant='body2'>{repostCount}</Typography>
         <IconButton aria-label='favorite'>
+          {/* Favorite の処理の呼び出しを行う */}
           <FavoriteIcon />
         </IconButton>
-        <Typography variant='body2'>{props.favCount}</Typography>
+        <Typography variant='body2'>{favCount}</Typography>
         <IconButton aria-label='share'>
           <ShareIcon />
         </IconButton>
       </CardActions>
     </Card>
   );
-};
+});
 
 export default Post;

--- a/client/components/ReplingToPost.tsx
+++ b/client/components/ReplingToPost.tsx
@@ -1,1 +1,0 @@
-export default function ReplingToPost() {}

--- a/client/components/ReplyingToPost.tsx
+++ b/client/components/ReplyingToPost.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { getCookie } from 'cookies-next';
+import { useTheme } from '@mui/material/styles';
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import AddPhotoAlternateOutlinedIcon from '@mui/icons-material/AddPhotoAlternateOutlined';
+import PollOutlinedIcon from '@mui/icons-material/PollOutlined';
+import PublishIcon from '@mui/icons-material/Publish';
+import Avatar from '@mui/material/Avatar';
+import Fab from '@mui/material/Fab';
+import IconButton from '@mui/material/IconButton';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { PostProps } from './Post';
+
+type ReplyingToPostProps = PostProps & { postHTML: JSX.Element; handleClose: () => void };
+
+const style = {
+  position: 'absolute' as 'absolute',
+  padding: '0px',
+  top: '25%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 680,
+  bgcolor: 'background.default',
+  border: 'none',
+  boxShadow: 24,
+  p: 4,
+  borderRadius: 5,
+};
+
+const ReplyingToPost = React.forwardRef<HTMLDivElement, ReplyingToPostProps>(
+  function ReplyingToPostImpl(
+    {
+      postId,
+      photoURL,
+      userName,
+      userId,
+      postText,
+      replyCount,
+      repostCount,
+      favCount,
+      postTime,
+      isFavedByU,
+      isRepostedByU,
+      postHTML,
+      handleClose,
+      ...cardProps
+    }: ReplyingToPostProps,
+    ref: React.ForwardedRef<HTMLDivElement>
+  ) {
+    const sendReply = () => {
+      // DB に対して返信の処理を行う
+      handleClose();
+    };
+
+    const theme = useTheme();
+    return (
+      <Card sx={style} ref={ref} {...cardProps}>
+        <CardHeader
+          avatar={<Avatar src={photoURL as string} aria-label='icon' />}
+          title={userName + '@' + userId}
+        />
+        <CardContent>{postHTML}</CardContent>
+        <CardHeader
+          avatar={<Avatar src={getCookie('photoURL') as string} aria-label='icon' />}
+          title={getCookie('userName') + '@' + getCookie('userId')}
+        />
+        <CardContent>
+          <TextareaAutosize
+            aria-label='posttext'
+            placeholder='返信を書き込んでください'
+            minRows={3}
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+              border: 'none',
+              resize: 'none',
+              outline: 'none',
+              backgroundColor: 'inherit',
+              color: theme.palette.text.primary,
+              fontSize: 18,
+            }}
+          />
+        </CardContent>
+        <CardActions disableSpacing>
+          <IconButton aria-label='add image'>
+            <AddPhotoAlternateOutlinedIcon />
+          </IconButton>
+          <IconButton aria-label='add poll'>
+            <PollOutlinedIcon />
+          </IconButton>
+          <Fab
+            variant='extended'
+            color='primary'
+            onClick={sendReply}
+            aria-label='send reply'
+            sx={{ width: 'auto', marginRight: 0, marginLeft: 'auto' }}
+          >
+            <PublishIcon />
+            返信
+          </Fab>
+        </CardActions>
+      </Card>
+    );
+  }
+);
+
+export default ReplyingToPost;

--- a/client/components/Timeline.tsx
+++ b/client/components/Timeline.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import Post, { PostProps } from './Post';
@@ -26,7 +28,7 @@ const Timeline = () => {
       postText: 'Welcome to UEC!',
       replyCount: 1,
       repostCount: 2,
-      favCount: 3,
+      favCount: 5,
       postTime: 'February 21, 2023',
       isFavedByU: true,
       isRepostedByU: true,
@@ -34,6 +36,9 @@ const Timeline = () => {
   ];
   const [posts, setPosts] = useState<PostProps[]>(testPosts);
   // 無限スクロールを実装する
+
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.up('md'));
 
   return (
     <Stack divider={<Divider />}>

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       #- node_modules:/var/www/html/node_modules
     ports:
       - 3000:3000
-    command: sh -c "yarn build && yarn start"
+    #command: sh -c "yarn dev"
     tty: true
 #volumes:
 #node_modules:

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "next",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/client/package.json
+++ b/client/package.json
@@ -15,8 +15,7 @@
     "cookies-next": "^2.1.1",
     "next": "12",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "styled-components": "^5.3.6"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.43",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@emotion/babel-preset-css-prop": "^11.10.0",
     "@types/node": "^17.0.43",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -6,6 +6,9 @@ const darkTheme = createTheme({
   palette: {
     mode: 'dark',
   },
+  typography: {
+    fontSize: 16,
+  },
 });
 
 const App = ({ Component, pageProps }: AppProps) => {

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -1,33 +1,11 @@
-import Document, { DocumentContext, DocumentInitialProps } from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+import Document, { DocumentContext, DocumentInitialProps } from 'next/document';
 
-export default class MyDocument extends Document {
-  static async getInitialProps(
-    ctx: DocumentContext,
-  ): Promise<DocumentInitialProps> {
-    const sheet = new ServerStyleSheet()
-    const originalRenderPage = ctx.renderPage
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const initialProps = await Document.getInitialProps(ctx);
 
-    try {
-      ctx.renderPage = () =>
-        originalRenderPage({
-          enhanceApp: (App) => (props) =>
-            sheet.collectStyles(<App {...props} />),
-        })
-
-      const initialProps = await Document.getInitialProps(ctx)
-
-      return {
-        ...initialProps,
-        styles: [
-          <>
-            {initialProps.styles}
-            {sheet.getStyleElement()}
-          </>,
-        ],
-      }
-    } finally {
-      sheet.seal()
-    }
+    return initialProps;
   }
 }
+
+export default MyDocument;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9,12 +9,24 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/helper-module-imports@^7.16.7":
+"@babel/helper-annotate-as-pure@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
+  integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
+  integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
 
 "@babel/helper-string-parser@^7.19.4":
   version "7.19.4"
@@ -35,6 +47,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/plugin-syntax-jsx@^7.17.12", "@babel/plugin-syntax-jsx@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
+"@babel/plugin-transform-react-jsx@^7.17.12":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.0.tgz#656b42c2fdea0a6d8762075d58ef9d4e3c4ab8a2"
+  integrity sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-jsx" "^7.18.6"
+    "@babel/types" "^7.21.0"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.20.13"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz"
@@ -51,7 +81,23 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@emotion/babel-plugin@^11.10.6":
+"@babel/types@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.0.tgz#1da00d89c2f18b226c9207d96edbeb79316a1819"
+  integrity sha512-uR7NWq2VNFnDi7EYqiRz2Jv/VQIu38tu64Zy8TX2nQFQ6etJ9V/Rr2msW8BS132mum2rL645qpDrLtAJtVpuow==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@emotion/babel-plugin-jsx-pragmatic@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.2.0.tgz#6fdd78600417973fa2610704693158181d8505b7"
+  integrity sha512-VPfKAtb/bVyu5y+HzCPj9bb2nHnj9yX5mMAU7N0pIDcrFZo8aqDyHXLYF8BD7tY4pNL09N87dygVLKIkQvshJw==
+  dependencies:
+    "@babel/plugin-syntax-jsx" "^7.17.12"
+
+"@emotion/babel-plugin@^11.10.0", "@emotion/babel-plugin@^11.10.6":
   version "11.10.6"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz"
   integrity sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==
@@ -67,6 +113,16 @@
     find-root "^1.1.0"
     source-map "^0.5.7"
     stylis "4.1.3"
+
+"@emotion/babel-preset-css-prop@^11.10.0":
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-11.10.0.tgz#23922787561d8376782b0e9006323512fe797275"
+  integrity sha512-oN2lCP0NJTEt80IIeFM1RbmapeEVNYzKXYk2pYirAuom9WvV9Oz/aJQN5Hn3RyBMPaY+Of1OZYpTVMle2jUm4g==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.17.12"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.0"
+    "@emotion/babel-plugin-jsx-pragmatic" "^0.2.0"
 
 "@emotion/cache@^11.10.5":
   version "11.10.5"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,60 +2,17 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.0.0":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/generator@^7.20.7":
-  version "7.20.14"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz"
-  integrity sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==
-  dependencies:
-    "@babel/types" "^7.20.7"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    jsesc "^2.5.1"
-
-"@babel/helper-annotate-as-pure@^7.16.0":
-  version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz"
-  integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz"
-  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
-
-"@babel/helper-function-name@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz"
-  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/types" "^7.19.0"
-
-"@babel/helper-hoist-variables@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz"
-  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.0", "@babel/helper-module-imports@^7.16.7":
+"@babel/helper-module-imports@^7.16.7":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-split-export-declaration@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz"
-  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
   dependencies:
     "@babel/types" "^7.18.6"
 
@@ -78,11 +35,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.20.13", "@babel/parser@^7.20.7":
-  version "7.20.15"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz"
-  integrity sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==
-
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.20.13"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz"
@@ -90,32 +42,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@^7.18.10":
-  version "7.20.7"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz"
-  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.20.7"
-    "@babel/types" "^7.20.7"
-
-"@babel/traverse@^7.4.5":
-  version "7.20.13"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz"
-  integrity sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.7"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.20.13"
-    "@babel/types" "^7.20.7"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
-"@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.20.7":
+"@babel/types@^7.18.6":
   version "7.20.7"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
@@ -157,7 +84,7 @@
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
-"@emotion/is-prop-valid@^1.1.0", "@emotion/is-prop-valid@^1.2.0":
+"@emotion/is-prop-valid@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz"
   integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
@@ -210,16 +137,6 @@
     "@emotion/serialize" "^1.1.1"
     "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
     "@emotion/utils" "^1.2.0"
-
-"@emotion/stylis@^0.8.4":
-  version "0.8.5"
-  resolved "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz"
-  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
-
-"@emotion/unitless@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz"
-  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@emotion/unitless@^0.8.0":
   version "0.8.0"
@@ -274,38 +191,6 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
-
-"@jridgewell/gen-mapping@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-    "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
-
-"@jridgewell/set-array@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz"
-  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
-
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.17"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
-  dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@mui/base@5.0.0-alpha.118":
   version "5.0.0-alpha.118"
@@ -782,22 +667,6 @@ babel-plugin-macros@^3.1.0:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-"babel-plugin-styled-components@>= 1.12.0":
-  version "2.0.7"
-  resolved "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz"
-  integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-module-imports" "^7.16.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.11"
-    picomatch "^2.3.0"
-
-babel-plugin-syntax-jsx@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz"
-  integrity sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -830,11 +699,6 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
-camelize@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz"
-  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001406:
   version "1.0.30001451"
@@ -931,20 +795,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz"
-  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
-
-css-to-react-native@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz"
-  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^4.0.2"
-
 csstype@^3.0.2, csstype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz"
@@ -962,7 +812,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1534,11 +1384,6 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.1.0:
-  version "11.12.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-
 globals@^13.19.0:
   version "13.20.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
@@ -1649,7 +1494,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -1895,11 +1740,6 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsesc@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
-  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
-
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
@@ -1966,11 +1806,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash@^4.17.11:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -2214,15 +2049,10 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.3.0, picomatch@^2.3.1:
+picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-postcss-value-parser@^4.0.2:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
-  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@8.4.14:
   version "8.4.14"
@@ -2386,11 +2216,6 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -2488,22 +2313,6 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-styled-components@^5.3.6:
-  version "5.3.6"
-  resolved "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz"
-  integrity sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^1.1.0"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
-
 styled-jsx@5.0.7:
   version "5.0.7"
   resolved "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz"
@@ -2514,7 +2323,7 @@ stylis@4.1.3:
   resolved "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz"
   integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
Closes #19 
- リプライ画面を実装した
- 子コンポーネントまたは `component` プロパティとして MUI コンポーネントに渡すコンポーネントは React.forwardRef コンポーネントにしないとブラウザの console タブでエラーが出るので修正した([参考](https://mui.com/material-ui/guides/composition/#caveat-with-refs))
- そのほか UI を改善した